### PR TITLE
Dim the buttons

### DIFF
--- a/floatVideo.css
+++ b/floatVideo.css
@@ -51,6 +51,10 @@
 
 .mnfb-play-button-pause {
   display: none;
+  opacity: 0.5;
+}
+.mnfb-play-button:hover .mnfb-play-button-pause{
+  opacity: 1;
 }
 
 .mnfb-play-button-pause:before {
@@ -213,6 +217,8 @@
   font-weight: bold;
   text-decoration: none;
   color:#ffffff;
+
+  opacity: 0.5;
 }
 
 #mnfb-play-button{
@@ -225,6 +231,7 @@
 
 .mnfb-size-button:hover {
   background-color: #3b5998;
+  opacity: 1;
 }
 
 .mnfb-pin-label {


### PR DESCRIPTION
How about dimming the buttons (opacity) when the mouse hovers on the player?
The reason behind this is I was reading some text on the video and i was scrolling through the video very quickly (which mean my mouse will always be on the player). The buttons were so bright that it was making it difficult to read the text because of the buttons.
What do you think about it ?
